### PR TITLE
fix python 3.10 compat with lmdb

### DIFF
--- a/stones/lmdb.py
+++ b/stones/lmdb.py
@@ -8,7 +8,7 @@ try:
 except ModuleNotFoundError:
     print('LMDB store requires PyPi.python.org/pypi/lmdb')
 
-LMDB_ENVIRONMENT = {'max_dbs': 9, 'map_size': 8e12}
+LMDB_ENVIRONMENT = {'max_dbs': 9, 'map_size': int(8e12)}
 
 
 class LmdbStore(BaseStore):


### PR DESCRIPTION
On python 3.8, using a float gives a warning:

```
>>> lmdb.open('foobarbaz', **{'max_dbs': 9, 'map_size': 8000000000000.0}, **{'map_async': True})
DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
```

While on python 3.10, it crashes with:

```
>>> lmdb.open('foobarbaz', **{'max_dbs': 9, 'map_size': 8000000000000.0}, **{'map_async': True})
InvalidParameterError: foobarbaz: Invalid argument
```

While this works:

```
>>> lmdb.open('foobarbaz', **{'max_dbs': 9, 'map_size': 8000000000000}, **{'map_async': True})
<Environment at 0x1091f8ed0>
```